### PR TITLE
MPTCP moved to Libera

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ This is an ongoing list of projects and channels that have decided to permanentl
 - [Monitoring Plugins](https://twitter.com/monitorplugins/status/1397995984978956290)
 - [MorphOS](https://www.amiga-news.de/en/news/AN-2021-05-00064-EN.html)
 - [Mousepaw Media](https://twitter.com/mousepawmedia/status/1397727750069227524)
+- [MPTCP](https://lore.kernel.org/mptcp/71bceb9e-cfc8-4577-5828-237fc66b753f@tessares.net/T/#u)
 - [mpv](https://twitter.com/mpv_player/status/1399663401903734784)
 - [MUGS (Multi-User Gaming Services)](https://github.com/Raku-MUGS/MUGS-Core/commit/f018d134fcf79cf0116e5ffa288b7fb8b10ee09c)
 - [Music Player Daemon (MPD)](https://www.musicpd.org/news/2021/05/bye-freenode-hello-libera-dot-chat/)


### PR DESCRIPTION
Official announcement:

  https://lore.kernel.org/mptcp/71bceb9e-cfc8-4577-5828-237fc66b753f@tessares.net/T/#u

More details about the channels that are now used:

  https://github.com/multipath-tcp/mptcp_net-next/wiki/IRC